### PR TITLE
Add docs for billing API with organization_id

### DIFF
--- a/billing/api-endpoints.md
+++ b/billing/api-endpoints.md
@@ -13,13 +13,14 @@ These endpoints allow you to handle Stripe subscriptions for Publish and Analyze
 ___
 
 ### GET /1/billing/retrieve-billing-data.json
-Get basics billing data for the current user. (it has been poorly implemented for now to unblock the Analyze team, and should only be used by Analyze) `official client only`
+Get basics billing data for the current user or for a given organization ID (as long as the current user is part of that organization). (it has been poorly implemented for now to unblock the Analyze team, and should only be used by Analyze) `official client only`
 
 **Parameters**
 
 |          Name | Required |  Type   | Description                                                                                                                                                           |
 | -------------:|:--------:|:-------:| --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 |     `product` | required | string  | The product for which to perform the action. <br/><br/> Supported values: `publish` or `analyze`.                                                                     |
+|     `organization_id` | optional | string  | The organization ID for which to perform the action. <br/><br/> Default is `null`. <br/><br/> If passed, we will check if the user is part of that organization before returning any information.                                                                     |
 
 **Response**
 


### PR DESCRIPTION
Update information on billing API endpoints with the new `organization_id` parameter.